### PR TITLE
Fixed sRGB conversion : only for Color/LatLonCubemaps

### DIFF
--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -302,11 +302,15 @@ namespace Mixture
                         contents = ImageConversion.EncodeToEXR(outputTexture as Texture2D);
                     else
                     {
-
                         var colors = (outputTexture as Texture2D).GetPixels();
-                        for (int i = 0; i < colors.Length; i++)
+
+                        if(external.external2DOoutputType == ExternalOutputNode.External2DOutputType.Color || 
+                            external.external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLonCubemap)
                         {
-                            colors[i] = colors[i].gamma;
+                            for (int i = 0; i < colors.Length; i++)
+                            {
+                                colors[i] = colors[i].gamma;
+                            }
                         }
                         (outputTexture as Texture2D).SetPixels(colors);
 


### PR DESCRIPTION
Small fix for external outputs: will only convert linear color to RGB if output is supposed to be a color one. (Leaves values untouched for Normal/Linear)