### PR TITLE
External Output sRGB Write Fix / sRGB Preview Fixes

### DIFF
--- a/Packages/com.alelievr.mixture/Editor/Resources/UI Blocks/Preview.uxml
+++ b/Packages/com.alelievr.mixture/Editor/Resources/UI Blocks/Preview.uxml
@@ -13,6 +13,7 @@
                 <ui:VisualElement name="MipMapLow" style="background-image: resource(&apos;Icons/TextureMipMapLow&apos;); width: 16px; height: 16px; margin-top: 1px;" />
                 <ui:Label text="0" name="MipMapNumberText" style="-unity-text-align: middle-center; width: 20px;" />
             </ui:VisualElement>
+            <uie:ToolbarToggle label="sRGB" value="true" name="ToggleSRGB" style="width: 44px; font-size: 14px;" />
         </uie:Toolbar>
         <ui:VisualElement name="SliceInputs" style="flex-direction: row;">
             <ui:VisualElement name="LayersIcon" style="width: 18px; height: 16px; background-image: resource(&apos;Icons/LayersIcon&apos;); -unity-background-image-tint-color: rgb(127, 127, 127);" />

--- a/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
@@ -105,13 +105,19 @@ namespace Mixture
                     }
                 }
 
+                EditorGUI.BeginChangeCheck();
+                var exportAlpha = EditorGUILayout.Toggle("Export Alpha", externalOutputNode.exportAlpha);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    externalOutputNode.exportAlpha = exportAlpha;
+                    MarkDirtyRepaint();
+                }
+
                 externalOutputNode.previewSRGB =
-
-                externalOutputNode.externalFileType == ExternalOutputNode.ExternalFileType.PNG &&
-                externalOutputNode.externalOutputDimension == ExternalOutputNode.ExternalOutputDimension.Texture2D &&
-                    (externalOutputNode.external2DOoutputType == ExternalOutputNode.External2DOutputType.Color ||
-                    externalOutputNode.external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLongCubemapColor);
-
+                    externalOutputNode.externalFileType == ExternalOutputNode.ExternalFileType.PNG &&
+                    externalOutputNode.externalOutputDimension == ExternalOutputNode.ExternalOutputDimension.Texture2D &&
+                        (externalOutputNode.external2DOoutputType == ExternalOutputNode.External2DOutputType.Color ||
+                        externalOutputNode.external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLongCubemapColor);
 
                 GUILayout.Space(8);
             }

--- a/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
@@ -83,6 +83,16 @@ namespace Mixture
                         externalOutputNode.external2DOoutputType = (ExternalOutputNode.External2DOutputType)outputType;
                         MarkDirtyRepaint();
                     }
+
+                    EditorGUI.BeginChangeCheck();
+                    var outputFileType = EditorGUILayout.EnumPopup("File Type", externalOutputNode.externalFileType);
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        externalOutputNode.externalFileType = (ExternalOutputNode.ExternalFileType)outputFileType;
+                        UpdateButtons();
+                        MarkDirtyRepaint();
+                    }
+
                 }
                 else if (externalOutputNode.externalOutputDimension == ExternalOutputNode.ExternalOutputDimension.Texture3D)
                 {
@@ -94,6 +104,8 @@ namespace Mixture
                         MarkDirtyRepaint();
                     }
                 }
+
+
                 GUILayout.Space(8);
             }
             );
@@ -149,7 +161,14 @@ namespace Mixture
                     // Manage First save or Update
                     button.save.style.display = DisplayStyle.Flex;
                     button.update.style.display = DisplayStyle.Flex;
-                    button.update.SetEnabled(externalOutputNode.asset != null);
+
+                    bool valid = externalOutputNode.asset != null && (
+                        (AssetDatabase.GetAssetPath(externalOutputNode.asset).ToLower().EndsWith("exr") && externalOutputNode.externalFileType == ExternalOutputNode.ExternalFileType.EXR)
+                        || (AssetDatabase.GetAssetPath(externalOutputNode.asset).ToLower().EndsWith("png") && externalOutputNode.externalFileType == ExternalOutputNode.ExternalFileType.PNG)
+                        || (AssetDatabase.GetAssetPath(externalOutputNode.asset).ToLower().EndsWith("asset") && externalOutputNode.externalOutputDimension != ExternalOutputNode.ExternalOutputDimension.Texture2D)) ;
+
+                    button.update.SetEnabled(valid);
+
                 }
             }
         }

--- a/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
@@ -105,6 +105,13 @@ namespace Mixture
                     }
                 }
 
+                externalOutputNode.previewSRGB =
+
+                externalOutputNode.externalFileType == ExternalOutputNode.ExternalFileType.PNG &&
+                externalOutputNode.externalOutputDimension == ExternalOutputNode.ExternalOutputDimension.Texture2D &&
+                    (externalOutputNode.external2DOoutputType == ExternalOutputNode.External2DOutputType.Color ||
+                    externalOutputNode.external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLongCubemapColor);
+
 
                 GUILayout.Space(8);
             }

--- a/Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
@@ -606,7 +606,7 @@ namespace Mixture
 					MixtureUtils.texture2DPreviewMaterial.SetVector("_Channels", MixtureEditorUtils.GetChannelsMask(nodeTarget.previewMode));
 					MixtureUtils.texture2DPreviewMaterial.SetFloat("_PreviewMip", nodeTarget.previewMip);
 					MixtureUtils.texture2DPreviewMaterial.SetFloat("_EV100", nodeTarget.previewEV100);
-					MixtureUtils.texture2DPreviewMaterial.SetFloat("_IsSRGB", nodeTarget.previewSRGB?1:0);
+					MixtureUtils.texture2DPreviewMaterial.SetFloat("_IsSRGB", nodeTarget.previewSRGB? 1 : 0);
 
 					if (Event.current.type == EventType.Repaint)
 						EditorGUI.DrawPreviewTexture(previewRect, node.previewTexture, MixtureUtils.texture2DPreviewMaterial, ScaleMode.ScaleToFit, 0, 0);
@@ -617,7 +617,7 @@ namespace Mixture
 					MixtureUtils.texture3DPreviewMaterial.SetFloat("_PreviewMip", nodeTarget.previewMip);
 					MixtureUtils.texture3DPreviewMaterial.SetFloat("_Depth", currentSlice / nodeTarget.settings.GetResolvedDepth(owner.graph));
 					MixtureUtils.texture3DPreviewMaterial.SetFloat("_EV100", nodeTarget.previewEV100);
-					MixtureUtils.texture3DPreviewMaterial.SetFloat("_IsSRGB", 0);
+					MixtureUtils.texture3DPreviewMaterial.SetFloat("_IsSRGB", nodeTarget.previewSRGB ? 1 : 0);
 
 					if (Event.current.type == EventType.Repaint)
 						EditorGUI.DrawPreviewTexture(previewRect, Texture2D.whiteTexture, MixtureUtils.texture3DPreviewMaterial, ScaleMode.ScaleToFit, 0, 0, ColorWriteMask.Red);
@@ -627,7 +627,7 @@ namespace Mixture
 					MixtureUtils.textureCubePreviewMaterial.SetVector("_Channels", MixtureEditorUtils.GetChannelsMask(nodeTarget.previewMode));
 					MixtureUtils.textureCubePreviewMaterial.SetFloat("_PreviewMip", nodeTarget.previewMip);
 					MixtureUtils.textureCubePreviewMaterial.SetFloat("_EV100", nodeTarget.previewEV100);
-					MixtureUtils.textureCubePreviewMaterial.SetFloat("_IsSRGB",  0);
+					MixtureUtils.textureCubePreviewMaterial.SetFloat("_IsSRGB", nodeTarget.previewSRGB ? 1 : 0);
 
 					if (Event.current.type == EventType.Repaint)
 						EditorGUI.DrawPreviewTexture(previewRect, Texture2D.whiteTexture, MixtureUtils.textureCubePreviewMaterial, ScaleMode.ScaleToFit, 0, 0);

--- a/Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
@@ -488,6 +488,20 @@ namespace Mixture
 			}
 
 			GUILayout.FlexibleSpace();
+
+			if(nodeTarget.canEditPreviewSRGB)
+            {
+				EditorGUI.BeginChangeCheck();
+
+				bool srgb = GUILayout.Toggle(nodeTarget.previewSRGB, "sRGB", EditorStyles.toolbarButton);
+
+				if (EditorGUI.EndChangeCheck())
+				{
+					owner.RegisterCompleteObjectUndo("Updated Preview Masks");
+					nodeTarget.previewSRGB = srgb;
+				}
+			}
+
 		}
 
 		void DrawTextureInfoHover(Rect previewRect, Texture texture)
@@ -592,7 +606,7 @@ namespace Mixture
 					MixtureUtils.texture2DPreviewMaterial.SetVector("_Channels", MixtureEditorUtils.GetChannelsMask(nodeTarget.previewMode));
 					MixtureUtils.texture2DPreviewMaterial.SetFloat("_PreviewMip", nodeTarget.previewMip);
 					MixtureUtils.texture2DPreviewMaterial.SetFloat("_EV100", nodeTarget.previewEV100);
-					MixtureUtils.texture2DPreviewMaterial.SetFloat("_IsSRGB", 0);
+					MixtureUtils.texture2DPreviewMaterial.SetFloat("_IsSRGB", nodeTarget.previewSRGB?1:0);
 
 					if (Event.current.type == EventType.Repaint)
 						EditorGUI.DrawPreviewTexture(previewRect, node.previewTexture, MixtureUtils.texture2DPreviewMaterial, ScaleMode.ScaleToFit, 0, 0);

--- a/Packages/com.alelievr.mixture/Editor/Views/NodeTexturePreview.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/NodeTexturePreview.cs
@@ -19,7 +19,7 @@ namespace Mixture
         
         // Texture Preview elements
         VisualElement   previewContainer;
-        Toggle          rgb, r, g, b, a;
+        Toggle          rgb, r, g, b, a, srgb;
         VisualElement   mipmapInputs;
         SliderInt       mipmapSlider;
         Label           currentMipIndex;
@@ -52,7 +52,7 @@ namespace Mixture
             g = previewRoot.Q("ToggleG") as Toggle;
             b = previewRoot.Q("ToggleB") as Toggle;
             a = previewRoot.Q("ToggleA") as Toggle;
-
+            srgb = previewRoot.Q("ToggleSRGB") as Toggle;
             mipmapSlider = previewRoot.Q("MipMapSlider") as SliderInt;
             mipmapInputs = previewRoot.Q("MipMapInput") as VisualElement;
             currentMipIndex = previewRoot.Q("MipMapNumberText") as Label;
@@ -104,6 +104,7 @@ namespace Mixture
 					MixtureUtils.texture2DPreviewMaterial.SetVector("_Channels", MixtureEditorUtils.GetChannelsMask(node.previewMode));
 					MixtureUtils.texture2DPreviewMaterial.SetFloat("_PreviewMip", node.previewMip);
 					MixtureUtils.texture2DPreviewMaterial.SetFloat("_EV100", node.previewEV100);
+                    MixtureUtils.texture2DPreviewMaterial.SetInt("_IsSRGB", node.previewSRGB ? 1 : 0);
 
 					if (Event.current.type == EventType.Repaint)
 						EditorGUI.DrawPreviewTexture(previewRect, node.previewTexture, MixtureUtils.texture2DPreviewMaterial, ScaleMode.ScaleToFit, 0, 0);

--- a/Packages/com.alelievr.mixture/Editor/Views/NodeTexturePreview.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/NodeTexturePreview.cs
@@ -115,8 +115,9 @@ namespace Mixture
 					MixtureUtils.texture3DPreviewMaterial.SetFloat("_PreviewMip", node.previewMip);
 					MixtureUtils.texture3DPreviewMaterial.SetFloat("_Depth", (node.previewSlice + 0.5f) / node.settings.GetResolvedDepth(graphView.graph));
 					MixtureUtils.texture3DPreviewMaterial.SetFloat("_EV100", node.previewEV100);
+                    MixtureUtils.texture3DPreviewMaterial.SetInt("_IsSRGB", node.previewSRGB ? 1 : 0);
 
-					if (Event.current.type == EventType.Repaint)
+                    if (Event.current.type == EventType.Repaint)
 						EditorGUI.DrawPreviewTexture(previewRect, Texture2D.whiteTexture, MixtureUtils.texture3DPreviewMaterial, ScaleMode.ScaleToFit, 0, 0, ColorWriteMask.Red);
 					break;
 				case TextureDimension.Cube:
@@ -124,8 +125,9 @@ namespace Mixture
 					MixtureUtils.textureCubePreviewMaterial.SetVector("_Channels", MixtureEditorUtils.GetChannelsMask(node.previewMode));
 					MixtureUtils.textureCubePreviewMaterial.SetFloat("_PreviewMip", node.previewMip);
 					MixtureUtils.textureCubePreviewMaterial.SetFloat("_EV100", node.previewEV100);
+                    MixtureUtils.textureCubePreviewMaterial.SetInt("_IsSRGB", node.previewSRGB ? 1 : 0);
 
-					if (Event.current.type == EventType.Repaint)
+                    if (Event.current.type == EventType.Repaint)
 						EditorGUI.DrawPreviewTexture(previewRect, Texture2D.whiteTexture, MixtureUtils.textureCubePreviewMaterial, ScaleMode.ScaleToFit, 0, 0);
 					break;
 				default:

--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -555,8 +555,7 @@ namespace Mixture
             try
             {
                 Texture outputTexture = null;
-                bool isHDR = external.settings.IsHDR(this);
-
+                
                 TextureDimension dimension = external.settings.GetResolvedTextureDimension(this);
                 GraphicsFormat format = (GraphicsFormat)external.settings.GetGraphicsFormat(this);
                 var rtSettings = external.settings;
@@ -629,9 +628,9 @@ namespace Mixture
                 {
                     byte[] contents = null;
 
-                    if (isHDR)
+                    if (external.externalFileType == ExternalOutputNode.ExternalFileType.EXR)
                         contents = ImageConversion.EncodeToEXR(outputTexture as Texture2D);
-                    else
+                    else if (external.externalFileType == ExternalOutputNode.ExternalFileType.PNG)
                     {
                         var colors = (outputTexture as Texture2D).GetPixels();
 
@@ -659,10 +658,12 @@ namespace Mixture
                         case ExternalOutputNode.External2DOutputType.Color:
                             importer.textureType = TextureImporterType.Default;
                             importer.sRGBTexture = true;
+                            importer.alphaSource = TextureImporterAlphaSource.FromInput;
                             break;
                         case ExternalOutputNode.External2DOutputType.Linear:
                             importer.textureType = TextureImporterType.Default;
                             importer.sRGBTexture = false;
+                            importer.alphaSource = TextureImporterAlphaSource.FromInput;
                             break;
                         case ExternalOutputNode.External2DOutputType.Normal:
                             importer.textureType = TextureImporterType.NormalMap;

--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -631,25 +631,7 @@ namespace Mixture
                     if (external.externalFileType == ExternalOutputNode.ExternalFileType.EXR)
                         contents = ImageConversion.EncodeToEXR(outputTexture as Texture2D);
                     else if (external.externalFileType == ExternalOutputNode.ExternalFileType.PNG)
-                    {
-                        var colors = (outputTexture as Texture2D).GetPixels();
-
-                        // We only do the conversion for whe the graph uses SRGB images
-                        // (peeweek) TODO: Remove this, as it is an unnecessary reverse-conversion because we have both sRGB
-                        // conversion happening in the finalOutput material AND by the texture importer
-                        // However if we remove this, AND the conversion in finalOutput, the preview will not look like the expected result.
-
-                        if (external.external2DOoutputType == ExternalOutputNode.External2DOutputType.Color
-                            || external.external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLongCubemapColor)
-                        {
-                            for (int i = 0; i < colors.Length; i++)
-                                colors[i] = colors[i].gamma;
-                        }
-
-                        (outputTexture as Texture2D).SetPixels(colors);
-
                         contents = ImageConversion.EncodeToPNG(outputTexture as Texture2D);
-                    }
 
                     System.IO.File.WriteAllBytes(System.IO.Path.GetDirectoryName(Application.dataPath) + "/" + assetPath, contents);
 

--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -635,6 +635,10 @@ namespace Mixture
                         var colors = (outputTexture as Texture2D).GetPixels();
 
                         // We only do the conversion for whe the graph uses SRGB images
+                        // (peeweek) TODO: Remove this, as it is an unnecessary reverse-conversion because we have both sRGB
+                        // conversion happening in the finalOutput material AND by the texture importer
+                        // However if we remove this, AND the conversion in finalOutput, the preview will not look like the expected result.
+
                         if (external.external2DOoutputType == ExternalOutputNode.External2DOutputType.Color
                             || external.external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLongCubemapColor)
                         {

--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -642,27 +642,33 @@ namespace Mixture
                     switch (external.external2DOoutputType)
                     {
                         case ExternalOutputNode.External2DOutputType.Color:
+                            importer.textureShape = TextureImporterShape.Texture2D;
                             importer.textureType = TextureImporterType.Default;
                             importer.sRGBTexture = true;
-                            importer.alphaSource = TextureImporterAlphaSource.FromInput;
+                            importer.alphaSource = external.exportAlpha? TextureImporterAlphaSource.FromInput : TextureImporterAlphaSource.None;
                             break;
                         case ExternalOutputNode.External2DOutputType.Linear:
+                            importer.textureShape = TextureImporterShape.Texture2D;
                             importer.textureType = TextureImporterType.Default;
                             importer.sRGBTexture = false;
-                            importer.alphaSource = TextureImporterAlphaSource.FromInput;
+                            importer.alphaSource = external.exportAlpha ? TextureImporterAlphaSource.FromInput : TextureImporterAlphaSource.None;
                             break;
                         case ExternalOutputNode.External2DOutputType.Normal:
+                            importer.textureShape = TextureImporterShape.Texture2D;
                             importer.textureType = TextureImporterType.NormalMap;
+                            importer.alphaSource = TextureImporterAlphaSource.None;
                             break;
                         case ExternalOutputNode.External2DOutputType.LatLongCubemapColor:
                             importer.textureShape = TextureImporterShape.TextureCube;
                             importer.generateCubemap = TextureImporterGenerateCubemap.Cylindrical;
                             importer.sRGBTexture = true;
+                            importer.alphaSource = external.exportAlpha ? TextureImporterAlphaSource.FromInput : TextureImporterAlphaSource.None;
                             break;
                         case ExternalOutputNode.External2DOutputType.LatLongCubemapLinear:
                             importer.textureShape = TextureImporterShape.TextureCube;
                             importer.generateCubemap = TextureImporterGenerateCubemap.Cylindrical;
                             importer.sRGBTexture = false;
+                            importer.alphaSource = external.exportAlpha ? TextureImporterAlphaSource.FromInput : TextureImporterAlphaSource.None;
                             break;
                     }
                     importer.SaveAndReimport();

--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -587,9 +587,9 @@ namespace Mixture
 
                     if (dimension == TextureDimension.Tex2D)
                     {
-                        if (isHDR)
+                        if (external.externalFileType == ExternalOutputNode.ExternalFileType.EXR)
                             extension = "exr";
-                        else
+                        else if (external.externalFileType == ExternalOutputNode.ExternalFileType.PNG)
                             extension = "png";
                     }
 

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/Constants/TextureNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/Constants/TextureNode.cs
@@ -29,7 +29,9 @@ The output type of the node will update according to the type of texture provide
 		[Output(name = "Texture")]
 		public Texture outputTexture;
 
-		public override bool 	hasSettings => false;
+        public override bool canEditPreviewSRGB => !IsInputImportedTexture();
+
+        public override bool 	hasSettings => false;
 		public override string	name => "Texture";
         public override Texture previewTexture => outputTexture;
 		public override bool	showDefaultInspector => true;
@@ -82,7 +84,10 @@ The output type of the node will update according to the type of texture provide
 #if UNITY_EDITOR
 			var importer = UnityEditor.AssetImporter.GetAtPath(UnityEditor.AssetDatabase.GetAssetPath(textureAsset));
 			if (importer is UnityEditor.TextureImporter textureImporter)
+            {
 				normalMap = textureImporter.textureType == UnityEditor.TextureImporterType.NormalMap;
+				previewSRGB = textureImporter.sRGBTexture;
+			}
 #endif
 
 			int targetWidth = textureAsset.width;
@@ -165,6 +170,16 @@ The output type of the node will update according to the type of texture provide
 
 			return true;
         }
+
+		bool IsInputImportedTexture()
+        {
+#if UNITY_EDITOR
+			var importer = UnityEditor.AssetImporter.GetAtPath(UnityEditor.AssetDatabase.GetAssetPath(textureAsset));
+			return importer != null && importer is UnityEditor.TextureImporter;
+#else
+			return false;
+#endif
+		}
 
 		public bool InitializeNodeFromObject(Texture value)
 		{

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/Constants/TextureNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/Constants/TextureNode.cs
@@ -86,7 +86,6 @@ The output type of the node will update according to the type of texture provide
 			if (importer is UnityEditor.TextureImporter textureImporter)
             {
 				normalMap = textureImporter.textureType == UnityEditor.TextureImporterType.NormalMap;
-				previewSRGB = textureImporter.sRGBTexture;
 			}
 #endif
 

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
@@ -30,6 +30,12 @@ For 3D and Cube textures, the file is exported as a .asset and can be use in ano
             LatLongCubemapColor,
             LatLongCubemapLinear,
         }
+        public enum ExternalFileType
+        {
+            PNG, 
+            EXR
+        }
+
 
         public override string name => "External Output";
 
@@ -37,6 +43,7 @@ For 3D and Cube textures, the file is exported as a .asset and can be use in ano
 
         public ExternalOutputDimension externalOutputDimension = ExternalOutputDimension.Texture2D;
         public External2DOutputType external2DOoutputType = External2DOutputType.Color;
+        public ExternalFileType externalFileType = ExternalFileType.PNG;
         public ConversionFormat external3DFormat = ConversionFormat.RGBA32;
 		public override Texture previewTexture => outputTextureSettings.Count > 0 ? (Texture)mainOutput.finalCopyRT : Texture2D.blackTexture;
 

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
@@ -49,6 +49,8 @@ For 3D and Cube textures, the file is exported as a .asset and can be use in ano
 
         public override bool hasSettings => true;
 
+        public override bool canEditPreviewSRGB => false;
+
         protected override MixtureSettings defaultSettings
         {
             get
@@ -89,7 +91,7 @@ For 3D and Cube textures, the file is exported as a .asset and can be use in ano
             {
                 if(settings.GetResolvedTextureDimension(graph) != TextureDimension.Cube)
                 {
-                    outputTextureSettings.First().sRGB = (external2DOoutputType == ExternalOutputNode.External2DOutputType.Color || external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLongCubemapColor);
+                    outputTextureSettings.First().sRGB = false;
                     return base.ProcessNode(cmd);
                 }
                 else

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
@@ -81,7 +81,10 @@ For 3D and Cube textures, the file is exported as a .asset and can be use in ano
             if(graph.type != MixtureGraphType.Realtime)
             {
                 if(settings.GetResolvedTextureDimension(graph) != TextureDimension.Cube)
+                {
+                    outputTextureSettings.First().sRGB = (external2DOoutputType == ExternalOutputNode.External2DOutputType.Color || external2DOoutputType == ExternalOutputNode.External2DOutputType.LatLongCubemapColor);
                     return base.ProcessNode(cmd);
+                }
                 else
                 {
                     if (uniqueMessages.Add("CubemapNotSupported"))

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
@@ -45,6 +45,8 @@ For 3D and Cube textures, the file is exported as a .asset and can be use in ano
         public External2DOutputType external2DOoutputType = External2DOutputType.Color;
         public ExternalFileType externalFileType = ExternalFileType.PNG;
         public ConversionFormat external3DFormat = ConversionFormat.RGBA32;
+        public bool exportAlpha = true;
+
 		public override Texture previewTexture => outputTextureSettings.Count > 0 ? (Texture)mainOutput.finalCopyRT : Texture2D.blackTexture;
 
         public override bool hasSettings => true;

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/MixtureNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/MixtureNode.cs
@@ -37,6 +37,10 @@ namespace Mixture
 			OutputDimension.CubeMap,
 		};
 		public virtual PreviewChannels		defaultPreviewChannels => PreviewChannels.RGBA;
+
+		public virtual bool					canEditPreviewSRGB => true;
+		public virtual bool					defaultPreviewSRGB => false;
+
 		public virtual bool					showDefaultInspector => false;
 		public virtual bool					showPreviewExposure => false;
 		[SerializeField, HideInInspector]
@@ -54,10 +58,13 @@ namespace Mixture
 
 		protected Dictionary<string, Material> temporaryMaterials = new Dictionary<string, Material>();
 
-        // UI Serialization
-        [SerializeField, HideInInspector]
-        public PreviewChannels previewMode;
-        [SerializeField, HideInInspector]
+		// UI Serialization
+		[SerializeField, HideInInspector]
+		public PreviewChannels previewMode;
+		[SerializeField, HideInInspector]
+		public bool previewSRGB;
+
+		[SerializeField, HideInInspector]
         public float previewMip = 0.0f;
         [SerializeField, HideInInspector]
         public bool previewVisible = true;
@@ -138,6 +145,7 @@ namespace Mixture
 			base.OnNodeCreated();
 			settings = defaultSettings;
 			previewMode = defaultPreviewChannels;
+			previewSRGB = defaultPreviewSRGB;
 
 			// Patch up inheritance mode with default value in graph
 			onEnabled += () => settings.SyncInheritanceMode(graph.defaultNodeInheritanceMode);

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/OutputNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/OutputNode.cs
@@ -22,7 +22,10 @@ namespace Mixture
 		public override Texture 	previewTexture => graph?.type == MixtureGraphType.Realtime ? outputTextureSettings[selectedPreviewIndex].finalCopyRT : outputTextureSettings.Count > 0 ? outputTextureSettings[selectedPreviewIndex].finalCopyRT : null;
 		public override float		nodeWidth => 350;
 
-		[SerializeField, HideInInspector]
+		public override bool canEditPreviewSRGB => false;
+		public override bool defaultPreviewSRGB => false;
+
+        [SerializeField, HideInInspector]
 		int _selectedPreviewIndex;
 		internal int selectedPreviewIndex
 		{
@@ -168,6 +171,9 @@ namespace Mixture
 			}
 
 			UpdateMessages();
+
+			// Never preview as sRGB, as output will be actually converted to sRGB (thus previewed as sRGB) if defined in settings.
+			previewSRGB = false;
 
 			foreach (var output in outputTextureSettings)
 			{


### PR DESCRIPTION
- ✔ **External Output sRGB Processing Fixes:**
  - Removed Manual gamma correction
  - Added correct sRGB flag to texture importer
  - Added option to select either PNG or EXR file type for External Output, determines file type
- ✔Added an optional sRGB Preview to nodes
  - API defines its value `previewSRGB` , whether it can be edited per node `canEditPreviewSRGB`, and default value `defaultPreviewSRGB`
  - Defaults to MixtureNode are editable, and preview linear
  - Updated OutputNode not to use this preview (sRGB conversion already happens in finalOutputMaterial, so it is unnecessary to apply another conversion to the preview)
  - Updated External Output node to preview sRGB when configured correctly. Removed sRGB conversion in finalOutputMaterial (this conversion is handled by texture importer), Removed manual inverse-conversion that happened in C#.
  - Updated Input Texture Node : sRGB preview toggle only happens if input texture is not an imported texture. If this is an imported texture, sRGB preview is determined from the Texture importer


(Also added the sRGB toggle to the UIElements schema but it seems it is not used yet)