### PR TITLE
UV Polar Node

### DIFF
--- a/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace Mixture
 {
 	[Documentation(@"
-Constant Polar UV. Note that for texture 2D, the z coordinate is set to 0.5.
+Constant Polar UV. Note that for texture 2D, the z coordinate is set to 0
 ")]
 
 	[System.Serializable, NodeMenuItem("Constants/UV Polar")]

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using GraphProcessor;
+using System.Linq;
+
+namespace Mixture
+{
+	[Documentation(@"
+Constant Polar UV. Note that for texture 2D, the z coordinate is set to 0.5.
+")]
+
+	[System.Serializable, NodeMenuItem("Constants/UV Polar")]
+	public class UVPolarNode : FixedShaderNode
+	{
+		public override string name => "UV Polar";
+
+		public override string shaderName => "Hidden/Mixture/UVPolar";
+
+		public override bool displayMaterialInspector => true;
+
+	}
+}

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs
@@ -19,5 +19,10 @@ Constant Polar UV. Note that for texture 2D, the z coordinate is set to 0.5.
 
 		public override bool displayMaterialInspector => true;
 
+		public override List<OutputDimension> supportedDimensions => new List<OutputDimension>() {
+			OutputDimension.Texture2D,
+			OutputDimension.Texture3D,
+		};
+
 	}
 }

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs.meta
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/FixedShaderNodes/UVPolarNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef75067de7e275246a987ea0c19ad6a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/Color/UVPolar.shader
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/Color/UVPolar.shader
@@ -18,18 +18,14 @@
 			#pragma fragment MixtureFragment
 			#pragma target 3.0
 
-			#pragma shader_feature CRT_2D CRT_3D CRT_CUBE
+			#pragma shader_feature CRT_2D CRT_3D
 
 			float4 _Scale;
 			float4 _Bias;
 
 			float4 mixture(v2f_customrendertexture IN) : SV_Target
 			{
-#ifdef CRT_CUBE
-				float d = dot(IN.direction.xyz, float3(0,1,0)) * 0.5 + 0.5;
-				float p = atan2(IN.direction.y, IN.direction.x) / 6.283185307 + 0.5;
-				return float4(d * _Scale.x + _Bias.x, p * _Scale.y + _Bias.y, 0, 1);
-#elif CRT_2D
+#ifdef CRT_2D
 				float d = length(IN.globalTexcoord.xy - 0.5) * 2;
 				float p = atan2(IN.globalTexcoord.y - 0.5, IN.globalTexcoord.x - 0.5) / 6.283185307 + 0.5;
 				return float4(d * _Scale.x + _Bias.x, p * _Scale.y + _Bias.y, 0, 1);

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/Color/UVPolar.shader
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/Color/UVPolar.shader
@@ -1,0 +1,46 @@
+﻿Shader "Hidden/Mixture/UVPolar"
+{	
+	Properties
+	{
+		[MixtureVector3]_Scale("UV Scale", Vector) = (1.0,1.0,1.0,0.0)
+		[MixtureVector3]_Bias("UV Bias", Vector) = (0.0,0.0,0.0,0.0)
+	}
+	SubShader
+	{
+		Tags { "RenderType"="Opaque" }
+		LOD 100
+
+		Pass
+		{
+			HLSLPROGRAM
+			#include "Packages/com.alelievr.mixture/Runtime/Shaders/MixtureFixed.hlsl"
+			#pragma vertex CustomRenderTextureVertexShader
+			#pragma fragment MixtureFragment
+			#pragma target 3.0
+
+			#pragma shader_feature CRT_2D CRT_3D CRT_CUBE
+
+			float4 _Scale;
+			float4 _Bias;
+
+			float4 mixture(v2f_customrendertexture IN) : SV_Target
+			{
+#ifdef CRT_CUBE
+				float d = dot(IN.direction.xyz, float3(0,1,0)) * 0.5 + 0.5;
+				float p = atan2(IN.direction.y, IN.direction.x) / 6.283185307 + 0.5;
+				return float4(d * _Scale.x + _Bias.x, p * _Scale.y + _Bias.y, 0, 1);
+#elif CRT_2D
+				float d = length(IN.globalTexcoord.xy - 0.5) * 2;
+				float p = atan2(IN.globalTexcoord.y - 0.5, IN.globalTexcoord.x - 0.5) / 6.283185307 + 0.5;
+				return float4(d * _Scale.x + _Bias.x, p * _Scale.y + _Bias.y, 0, 1);
+#else
+				float d = length(IN.globalTexcoord.xyz - 0.5) * 2;
+				float p = atan2(IN.globalTexcoord.y - 0.5, IN.globalTexcoord.x - 0.5) / 6.283185307 + 0.5;
+				float t = dot(normalize(IN.globalTexcoord.xyz - 0.5), float3(0, 1, 0)) * 0.5 + 0.5;
+				return float4(d * _Scale.x + _Bias.x, p * _Scale.y + _Bias.y, t * _Scale.z + _Bias.z, 1);
+#endif
+			}
+			ENDHLSL
+		}
+	}
+}

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/Color/UVPolar.shader.meta
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/Color/UVPolar.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: eb44f73ac1821314db7d0e621223720a
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a UV Polar Node that generates 2D/3D UV Coordinates based on distance/tetha/phi.


2D Coordinates:
![image](https://user-images.githubusercontent.com/4037271/149636976-aa0f3f6f-2b9f-4753-a938-07e9ea34e4ab.png)


3D Coordinates:
![Unity_MAlzEgb753](https://user-images.githubusercontent.com/4037271/149637263-9a906201-3400-44e9-813a-d449c3c36d6a.gif)
