### PR TITLE
Swizzle Multiple Textures

### DIFF
--- a/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureSwizzleDrawer.cs
+++ b/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureSwizzleDrawer.cs
@@ -17,7 +17,16 @@ namespace Mixture
                 prop.floatValue = (float)value;
         }
 
-        static string[] displayedOptions = { "Input.Red", "Input.Green", "Input.Blue", "Input.Alpha", "Black", "Gray", "White", "Custom" };
-        static int[] optionValues = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        static string[] displayedOptions = { 
+            "Input A/Red", "Input A/Green", "Input A/Blue", "Input A/Alpha",
+            "Input B/Red", "Input B/Green", "Input B/Blue", "Input B/Alpha",
+            "Input C/Red", "Input C/Green", "Input C/Blue", "Input C/Alpha",
+            "Input D/Red", "Input D/Green", "Input D/Blue", "Input D/Alpha",
+            "Black", "Gray", "White", "Custom" };
+        static int[] optionValues = { 0, 1, 2, 3,
+            8, 9, 10, 11,
+            12, 13, 14, 15,
+            16, 17, 18, 19,
+            4, 5, 6, 7 };
     }
 }

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/MixtureUtils.hlsl
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/MixtureUtils.hlsl
@@ -252,19 +252,35 @@ float3 ScaleBias(float3 uv, float3 scale, float3 bias)
 float4 ScaleBias(float4 uv, float4 scale, float4 bias) { return float4(ScaleBias(uv.xyz, scale.xyz, bias.xyz), uv.a); }
 float2 ScaleBias(float2 uv, float2 scale, float2 bias) { return ScaleBias(float3(uv.xy, 0), float3(scale.xy, 0), float3(bias.xy, 0)).xy; }
 
-float Swizzle(float4 sourceValue, uint mode, float custom)
+float Swizzle(float4 sourceValueA, float4 sourceValueB, float4 sourceValueC, float4 sourceValueD, uint mode, float custom)
 {
 	switch (mode)
 	{
-	case 0: return sourceValue.x;
-	case 1: return sourceValue.y;
-	case 2: return sourceValue.z;
-	case 3: return sourceValue.w;
+	case 0: return sourceValueA.x;
+	case 1: return sourceValueA.y;
+	case 2: return sourceValueA.z;
+	case 3: return sourceValueA.w;
+
 	default:
 	case 4: return 0.0f;
 	case 5: return 0.5f;
 	case 6: return 1.0f;
 	case 7: return custom;
+
+	case 8:  return sourceValueB.x;
+	case 9:  return sourceValueB.y;
+	case 10: return sourceValueB.z;
+	case 11: return sourceValueB.w;
+
+	case 12: return sourceValueC.x;
+	case 13: return sourceValueC.y;
+	case 14: return sourceValueC.z;
+	case 15: return sourceValueC.w;
+
+	case 16: return sourceValueD.x;
+	case 17: return sourceValueD.y;
+	case 18: return sourceValueD.z;
+	case 19: return sourceValueD.w;
 	}
 	return 0;
 }

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/Utils/Swizzle.shader
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/Utils/Swizzle.shader
@@ -2,9 +2,21 @@
 {	
 	Properties
 	{
-		[InlineTexture]_Source_2D("Input", 2D) = "white" {}
-		[InlineTexture]_Source_3D("Input", 3D) = "white" {}
-		[InlineTexture]_Source_Cube("Input", Cube) = "white" {}
+		[InlineTexture]_SourceA_2D("Input A", 2D) = "white" {}
+		[InlineTexture]_SourceA_3D("Input A", 3D) = "white" {}
+		[InlineTexture]_SourceA_Cube("Input A", Cube) = "white" {}
+
+		[InlineTexture]_SourceB_2D("Input B", 2D) = "white" {}
+		[InlineTexture]_SourceB_3D("Input B", 3D) = "white" {}
+		[InlineTexture]_SourceB_Cube("Input B", Cube) = "white" {}
+
+		[InlineTexture]_SourceC_2D("Input C", 2D) = "white" {}
+		[InlineTexture]_SourceC_3D("Input C", 3D) = "white" {}
+		[InlineTexture]_SourceC_Cube("Input C", Cube) = "white" {}
+
+		[InlineTexture]_SourceD_2D("Input D", 2D) = "white" {}
+		[InlineTexture]_SourceD_3D("Input D", 3D) = "white" {}
+		[InlineTexture]_SourceD_Cube("Input D", Cube) = "white" {}
 
 		[MixtureSwizzle]_RMode("Output Red", Float) = 0
 		[MixtureSwizzle]_GMode("Output Green", Float) = 1
@@ -28,7 +40,10 @@
 
             #pragma shader_feature CRT_2D CRT_3D CRT_CUBE
 
-			TEXTURE_SAMPLER_X(_Source);
+			TEXTURE_SAMPLER_X(_SourceA);
+			TEXTURE_SAMPLER_X(_SourceB);
+			TEXTURE_SAMPLER_X(_SourceC);
+			TEXTURE_SAMPLER_X(_SourceD);
 
 			float _RMode;
 			float _GMode;
@@ -38,11 +53,15 @@
 
 			float4 mixture (v2f_customrendertexture i) : SV_Target
 			{
-				float4 source = SAMPLE_X(_Source, i.localTexcoord.xyz, i.direction);
-				float r = Swizzle(source, _RMode, _Custom.r);
-				float g = Swizzle(source, _GMode, _Custom.g);
-				float b = Swizzle(source, _BMode, _Custom.b);
-				float a = Swizzle(source, _AMode, _Custom.a);
+				float4 sourceA = SAMPLE_X(_SourceA, i.localTexcoord.xyz, i.direction);
+				float4 sourceB = SAMPLE_X(_SourceB, i.localTexcoord.xyz, i.direction);
+				float4 sourceC = SAMPLE_X(_SourceC, i.localTexcoord.xyz, i.direction);
+				float4 sourceD = SAMPLE_X(_SourceD, i.localTexcoord.xyz, i.direction);
+
+				float r = Swizzle(sourceA, sourceB, sourceC, sourceD, _RMode, _Custom.r);
+				float g = Swizzle(sourceA, sourceB, sourceC, sourceD, _GMode, _Custom.g);
+				float b = Swizzle(sourceA, sourceB, sourceC, sourceD, _BMode, _Custom.b);
+				float a = Swizzle(sourceA, sourceB, sourceC, sourceD, _AMode, _Custom.a);
 				return float4(r, g, b, a);
 			}
 			ENDHLSL


### PR DESCRIPTION
Improves the Swizzle node : adding four texture inputs, and enabling selction of any channel of any texture for the output channels.

Note: values were not changed so new enum entries are added at the end.

![image](https://user-images.githubusercontent.com/4037271/150181536-ec7660cc-d42a-43c6-8b31-9f98c9209a33.png)
