### PR TITLE
Add TGA Export to External Output Node

### DIFF
--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -590,6 +590,10 @@ namespace Mixture
                             extension = "exr";
                         else if (external.externalFileType == ExternalOutputNode.ExternalFileType.PNG)
                             extension = "png";
+                        else if (external.externalFileType == ExternalOutputNode.ExternalFileType.TGA)
+                            extension = "tga";
+                        else
+                            throw new NotImplementedException($"File type not handled : '{external.externalFileType}'");
                     }
 
                     assetPath = EditorUtility.SaveFilePanelInProject("Save Texture", external.name, extension, "Save Texture");
@@ -632,6 +636,11 @@ namespace Mixture
                         contents = ImageConversion.EncodeToEXR(outputTexture as Texture2D);
                     else if (external.externalFileType == ExternalOutputNode.ExternalFileType.PNG)
                         contents = ImageConversion.EncodeToPNG(outputTexture as Texture2D);
+                    else if (external.externalFileType == ExternalOutputNode.ExternalFileType.TGA)
+                        contents = ImageConversion.EncodeToTGA(outputTexture as Texture2D);
+                    else
+                        throw new NotImplementedException($"File type not handled : '{external.externalFileType}'");
+
 
                     System.IO.File.WriteAllBytes(System.IO.Path.GetDirectoryName(Application.dataPath) + "/" + assetPath, contents);
 

--- a/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Nodes/ExternalOutputNode.cs
@@ -33,7 +33,8 @@ For 3D and Cube textures, the file is exported as a .asset and can be use in ano
         public enum ExternalFileType
         {
             PNG, 
-            EXR
+            EXR,
+            TGA
         }
 
 


### PR DESCRIPTION
Adds targa as output file format for external output node.

![image](https://user-images.githubusercontent.com/4037271/150861611-1aa1fb6c-27a7-4ada-ad97-6a8b1c9b54d5.png)
