### PR TITLE
Addi x2-1 and x0.5+0.5 to Scale Bias

### DIFF
--- a/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/ScaleBiasDrawer.cs
+++ b/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/ScaleBiasDrawer.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace Mixture
+{
+    public class ScaleBiasDrawer : MixturePropertyDrawer
+    {
+        protected override void DrawerGUI (Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)
+        {
+            //Enum(ScaleBias,0,BiasScale,1,Scale,2,Bias,3,TwiceMinusOne,4,HalvePlusHalf,5)
+
+            int value = EditorGUI.IntPopup(position, label, (int)prop.floatValue, displayedOptions, optionValues);
+
+            if (GUI.changed)
+                prop.floatValue = (float)value;
+        }
+
+        static string[] displayedOptions = { "Scale Bias", "Bias Scale", "×2 -1 ", "×0.5 +0.5", "Scale", "Bias"};
+        static int[] optionValues = { 0, 1, 4, 5, 2, 3};
+    }
+}

--- a/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/ScaleBiasDrawer.cs.meta
+++ b/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/ScaleBiasDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6e4d9a043ef24a42bb42e0008c0d846
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/MixtureUtils.hlsl
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/MixtureUtils.hlsl
@@ -249,8 +249,17 @@ float3 ScaleBias(float3 uv, float3 scale, float3 bias)
     return (uv * scale) + bias;
 }
 
+float3 BiasScale(float3 uv, float3 scale, float3 bias)
+{
+	return (uv + bias) * scale;
+}
+
 float4 ScaleBias(float4 uv, float4 scale, float4 bias) { return float4(ScaleBias(uv.xyz, scale.xyz, bias.xyz), uv.a); }
 float2 ScaleBias(float2 uv, float2 scale, float2 bias) { return ScaleBias(float3(uv.xy, 0), float3(scale.xy, 0), float3(bias.xy, 0)).xy; }
+
+float4 BiasScale(float4 uv, float4 scale, float4 bias) { return float4(BiasScale(uv.xyz, scale.xyz, bias.xyz), uv.a); }
+float2 BiasScale(float2 uv, float2 scale, float2 bias) { return BiasScale(float3(uv.xy, 0), float3(scale.xy, 0), float3(bias.xy, 0)).xy; }
+
 
 float Swizzle(float4 sourceValue, uint mode, float custom)
 {

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/Operators/ScaleBias.shader
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/Operators/ScaleBias.shader
@@ -6,7 +6,7 @@
 		[InlineTexture]_Texture_3D("Texture", 3D) = "white" {}
 		[InlineTexture]_Texture_Cube("Texture", Cube) = "white" {}
 
-		[Enum(ScaleBias,0,BiasScale,1,Scale,2,Bias,3)]_Mode("Mode", Float) = 0
+		[ScaleBias]_Mode("Mode", Float) = 0
 		[MixtureVector3]_Scale("Scale", Vector) = (1.0,1.0,1.0,0.0)
 		[MixtureVector3]_Bias("Bias", Vector) = (0.0,0.0,0.0,0.0)
 	}
@@ -37,9 +37,11 @@
 				switch ((uint)_Mode)
 				{
 					case 0: col = ScaleBias(col, _Scale, _Bias); break;
-					case 1: col = ScaleBias(col, _Bias, _Scale); break;
+					case 1: col = BiasScale(col, _Scale, _Bias); break;
 					case 2: col = ScaleBias(col, _Scale, 0); break;
 					case 3: col = ScaleBias(col, 1, _Bias); break;
+					case 4: col = ScaleBias(col, 2, -1); break;
+					case 5: col = ScaleBias(col, 0.5, 0.5); break;
 				}
 				return col;
 			}


### PR DESCRIPTION
Adding two modes to the Scale bias for common Scale Bias cases. Used a MixturePropertyDrawer to better format entries of the enum

![image](https://user-images.githubusercontent.com/4037271/150874757-7a958235-b042-431a-aecd-5dcd8dfc68ec.png)
