### PR TITLE
Additional Modes for Remap Node

### DIFF
--- a/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureRemapModeDrawer.cs
+++ b/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureRemapModeDrawer.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace Mixture
+{
+    public class MixtureRemapModeDrawer : MixturePropertyDrawer
+    {
+        protected override void DrawerGUI (Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)
+        {
+            //Enum(Brightness (Gradient),0,Alpha (Curve),1,Brightness (Curve),2,Saturation (Curve),3,Hue (Curve),4,Red (Curve),5,Green (Curve),6,Blue (Curve),7)
+
+            int value = EditorGUI.IntPopup(position, label, (int)prop.floatValue, displayedOptions, optionValues);
+
+            if (GUI.changed)
+                prop.floatValue = (float)value;
+        }
+
+        static string[] displayedOptions = { "Brightness (Gradient)", "Red Channel (Curve)", "Green Channel (Curve)", "Blue Channel (Curve)", "Alpha Channel (Curve)", "All Channels (4 Curves)", "Brightness (Curve)", "Saturation (Curve)", "Hue (Curve)" };
+        static int[] optionValues = { 0, 5, 6, 7, 1, 8, 2, 3, 4 };
+    }
+}

--- a/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureRemapModeDrawer.cs.meta
+++ b/Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureRemapModeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2484ddb318b6bb148a50f7926abb1527
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.alelievr.mixture/Runtime/Shaders/Math/Remap.shader
+++ b/Packages/com.alelievr.mixture/Runtime/Shaders/Math/Remap.shader
@@ -8,7 +8,7 @@
 
 		_Map("Map",2D) = "white" {}
 
-		[Enum(Brightness (Gradient),0,Alpha (Curve),1,Brightness (Curve),2,Saturation (Curve),3,Hue (Curve),4)]_Mode("Mode", Float) = 0
+		[MixtureRemapMode]_Mode("Mode", Float) = 0
 	}
 	SubShader
 	{
@@ -51,6 +51,21 @@
 				case 4: // Hue from Curve
 					hsv.x = SAMPLE_2D(_Map, hsv.xxx).r;
 					return float4(HSVtoRGB(hsv), sourceValue.a);
+				case 5: // Red from Curve
+					sourceValue.r = SAMPLE_2D(_Map, sourceValue.rrr).r;
+					return sourceValue;
+				case 6: // Green from Curve
+					sourceValue.g = SAMPLE_2D(_Map, sourceValue.ggg).r;
+					return sourceValue;
+				case 7: // Blue from Curve
+					sourceValue.b = SAMPLE_2D(_Map, sourceValue.bbb).r;
+					return sourceValue;
+				case 8: // Blue from Curve
+					sourceValue.r = SAMPLE_2D(_Map, sourceValue.rrr).r;
+					sourceValue.g = SAMPLE_2D(_Map, sourceValue.ggg).g;
+					sourceValue.b = SAMPLE_2D(_Map, sourceValue.bbb).b;
+					sourceValue.a = SAMPLE_2D(_Map, sourceValue.aaa).a;
+					return sourceValue;
 				}
 				return 0;
 			}


### PR DESCRIPTION
**Added Additonal Modes to Remap Node:** 
- Red Channel from Curve : only remaps Red (from Red Curve)
- Green Channel from Curve : only remaps Green ((from Red Curve)
- Blue Channel from Curve : only remaps Blue ((from Red Curve)
- All Channels from 4 Curves : remaps each channel from a distinct curve (RGBA curve node)

Also better formatting using Mixture Property Drawer:

![image](https://user-images.githubusercontent.com/4037271/150877151-7e80773f-40a9-424d-b7db-f488aedfb824.png)
