### PR TITLE
Enable Auto Referenced in com.alelievr.Mixture.Editor.asmdef

### DIFF
--- a/Packages/com.alelievr.mixture/Editor/com.alelievr.Mixture.Editor.asmdef
+++ b/Packages/com.alelievr.mixture/Editor/com.alelievr.Mixture.Editor.asmdef
@@ -17,7 +17,7 @@
     "allowUnsafeCode": true,
     "overrideReferences": true,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [
         {


### PR DESCRIPTION
I would like to inherit a class from Mixture Editor assembly but unable to because `Auto Referenced` is not enabled for that assembly. Beside, I don't want the hassle of adding assembly definitions all over my project just because of this.