### PR TITLE
[Enhance] Restructure assemblies

### DIFF
--- a/Assets/GraphicTests/com.alelievr.mixture.tests.asmdef
+++ b/Assets/GraphicTests/com.alelievr.mixture.tests.asmdef
@@ -2,13 +2,13 @@
     "name": "com.alelievr.mixture.tests",
     "rootNamespace": "",
     "references": [
-        "UnityEngine.TestRunner",
-        "Mixture.Runtime",
-        "com.alelievr.NodeGraphProcessor.Runtime",
-        "UnityEngine.TestTools.Graphics",
-        "UnityEditor.TestRunner",
-        "Unity.ShaderGraph.GraphicsTests",
-        "UnityEditor.TestTools.Graphics"
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:fe40ba3f519cd4795b386f0ccc63a5a7",
+        "GUID:ca937d03ee5dd4d699091438dc0f3ae6",
+        "GUID:c081bc530f560634bb5c21d4b323a7f1",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:31660b124da7540378315e14658e3cc6",
+        "GUID:e18141520846dcc44b725b2f74e91229"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/CustomTextureNodes.cs
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/CustomTextureNodes.cs
@@ -1,4 +1,3 @@
-#if MIXTURE_SHADERGRAPH
 using UnityEngine;
 using UnityEditor.ShaderGraph;
 using UnityEditor.Graphing;
@@ -244,4 +243,3 @@ namespace Mixture
             => NeededCoordinateSpace.World;
     }
 }
-#endif

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/CustomTextureSubShader.cs
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/CustomTextureSubShader.cs
@@ -1,4 +1,3 @@
-#if MIXTURE_SHADERGRAPH
 using System;
 using System.Collections.Generic;
 using UnityEditor;
@@ -64,10 +63,9 @@ namespace Mixture
                 generatesPreview = true,
                 passes = new PassCollection
                 {
-                    { FullscreePasses.CustomRenderTexture },
+                    { FullscreenPasses.CustomRenderTexture },
                 },
             };
         }
     }
 }
-#endif

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/FullScreenPassTarget.cs
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/FullScreenPassTarget.cs
@@ -1,4 +1,3 @@
-#if MIXTURE_SHADERGRAPH
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -219,7 +218,7 @@ namespace Mixture
         public override bool WorksWithSRP(RenderPipelineAsset scriptableRenderPipeline) => true; 
     }
 
-    static class FullscreePasses
+    static class FullscreenPasses
     {
         public static PassDescriptor CustomRenderTexture = new PassDescriptor
         {
@@ -309,4 +308,3 @@ namespace Mixture
 
     }
 }
-#endif

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/LegacyMasterNodes.cs
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/LegacyMasterNodes.cs
@@ -1,9 +1,4 @@
-#if MIXTURE_SHADERGRAPH
 using System;
-using System.Linq;
-using UnityEditor.Graphing;
-using UnityEditor.ShaderGraph.Drawing.Controls;
-using UnityEngine;
 using UnityEditor.ShaderGraph;
 using UnityEditor.ShaderGraph.Legacy;
 
@@ -25,4 +20,3 @@ namespace Mixture
         public const int ColorSlotId = 0;
     }
 }
-#endif

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/MixtureShaderGraphCallbacks.cs
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/MixtureShaderGraphCallbacks.cs
@@ -1,0 +1,58 @@
+using UnityEditor;
+using UnityEditor.ProjectWindowCallback;
+using UnityEditor.ShaderGraph;
+using UnityEngine;
+
+namespace Mixture {
+	public static class MixtureShaderGraphCallbacks
+	{
+			public static readonly string	customMipMapShaderTemplate = "Templates/CustomMipMapTemplate";
+
+			[MenuItem("Assets/Create/Mixture/Fixed Shader Graph", false, 202)]
+			[MenuItem("Assets/Create/Shader/Custom Texture Graph", false, 200)]
+			public static void CreateCustomTextureShaderGraph()
+			{
+				var graphItem = ScriptableObject.CreateInstance< CustomtextureShaderGraphAction >();
+				ProjectWindowUtil.StartNameEditingIfProjectWindowExists(
+					0,
+					graphItem,
+					$"New Custom Texture Graph.{ShaderGraphImporter.Extension}",
+					Resources.Load<Texture2D>("sg_graph_icon@64"),
+					null
+				);
+			}
+
+			[MenuItem("Assets/Create/Mixture/Custom Mip Map Shader", false, 903)]
+			public static void CreateCustomMipMapShaderGraph()
+			{
+				var template = Resources.Load< TextAsset >(customMipMapShaderTemplate);
+				ProjectWindowUtil.CreateScriptAssetFromTemplateFile(AssetDatabase.GetAssetPath(template), "Custom MipMap");
+			}
+
+			static Shader ReimportShaderGraphResource(string resourcePath)
+			{
+				string fullPath = "Packages/com.alelievr.mixture/Editor/Resources/" + resourcePath;
+
+				AssetDatabase.ImportAsset(fullPath, ImportAssetOptions.DontDownloadFromCacheServer | ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+
+				return Resources.Load< Shader >(resourcePath);
+			}
+
+			class CustomtextureShaderGraphAction : EndNameEditAction
+			{
+				public static readonly string template = "Templates/CustomTextureGraphTemplate";
+
+				public override void Action(int instanceId, string pathName, string resourceFile)
+				{
+					var s = Resources.Load(template, typeof(Shader));
+
+					// In case there was a compilation error sg files can be broken so we re-import them
+					if (s == null)
+						s = ReimportShaderGraphResource(template);
+
+					AssetDatabase.CopyAsset(AssetDatabase.GetAssetPath(s), pathName);
+					ProjectWindowUtil.ShowCreatedAsset(AssetDatabase.LoadAssetAtPath<Shader>(pathName));
+				}
+			}
+	}
+}

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/MixtureShaderGraphCallbacks.cs.meta
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/MixtureShaderGraphCallbacks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41adabb070894ec4bbebb64a5eceece0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/com.alelievr.Mixture.Editor.CustomTextureShaderGraph.asmref
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/com.alelievr.Mixture.Editor.CustomTextureShaderGraph.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:be0903cd8e1546f498710afdc59db5eb"
+}

--- a/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/com.alelievr.Mixture.Editor.CustomTextureShaderGraph.asmref.meta
+++ b/Packages/com.alelievr.mixture/Editor/CustomTextureShaderGraph/com.alelievr.Mixture.Editor.CustomTextureShaderGraph.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 75da831077dc0e14a97b95061e6f4bdc
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
+++ b/Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
@@ -5,11 +5,6 @@ using System.Linq;
 using UnityEditor.ProjectWindowCallback;
 using System.IO;
 using System.Reflection;
-using UnityEngine.Experimental.Rendering;
-
-#if MIXTURE_SHADERGRAPH
-using UnityEditor.ShaderGraph;
-#endif
 
 namespace Mixture
 {
@@ -98,24 +93,6 @@ namespace Mixture
             	Path.GetFileName(path), targetGraph.type == MixtureGraphType.Realtime ? MixtureUtils.realtimeVariantIcon : MixtureUtils.iconVariant, null);
 		}
 
-#if MIXTURE_SHADERGRAPH
-		[MenuItem("Assets/Create/Mixture/Fixed Shader Graph", false, 202)]
-		[MenuItem("Assets/Create/Shader/Custom Texture Graph", false, 200)]
-		public static void CreateCustomTextureShaderGraph()
-		{
-			var graphItem = ScriptableObject.CreateInstance< CustomtextureShaderGraphAction >();
-            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, graphItem,
-                $"New Custom Texture Graph.{ShaderGraphImporter.Extension}", Resources.Load<Texture2D>("sg_graph_icon@64"), null);
-		}
-
-		[MenuItem("Assets/Create/Mixture/Custom Mip Map Shader", false, 903)]
-		public static void CreateCustomMipMapShaderGraph()
-		{
-			var template = Resources.Load< TextAsset >(customMipMapShaderTemplate);
-			ProjectWindowUtil.CreateScriptAssetFromTemplateFile(AssetDatabase.GetAssetPath(template), "Custom MipMap");
-		}
-#endif
-		
 		[MenuItem("Assets/Create/Mixture/C# Fixed Shader Node", false, 200)]
 		public static void CreateCSharpFixedShaderNode()
 		{
@@ -343,32 +320,6 @@ namespace Mixture
 				createScriptAsset.Invoke(null, new object[]{ pathName, resourceFile });
 				ProjectWindowUtil.ShowCreatedAsset(AssetDatabase.LoadAssetAtPath<Shader>(pathName));
 				AssetDatabase.Refresh();
-			}
-		}
-
-		static Shader ReimportShaderGraphResource(string resourcePath)
-		{
-			string fullPath = "Packages/com.alelievr.mixture/Editor/Resources/" + resourcePath;
-
-			AssetDatabase.ImportAsset(fullPath, ImportAssetOptions.DontDownloadFromCacheServer | ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
-
-			return Resources.Load< Shader >(resourcePath);
-		}
-
-		class CustomtextureShaderGraphAction : EndNameEditAction
-		{
-			public static readonly string template = "Templates/CustomTextureGraphTemplate";
-
-			public override void Action(int instanceId, string pathName, string resourceFile)
-			{
-				var s = Resources.Load(template, typeof(Shader));
-
-				// In case there was a compilation error sg files can be broken so we re-import them
-				if (s == null)
-					s = ReimportShaderGraphResource(template);
-
-				AssetDatabase.CopyAsset(AssetDatabase.GetAssetPath(s), pathName);
-				ProjectWindowUtil.ShowCreatedAsset(AssetDatabase.LoadAssetAtPath<Shader>(pathName));
 			}
 		}
 	}

--- a/Packages/com.alelievr.mixture/Editor/com.alelievr.Mixture.Editor.asmdef
+++ b/Packages/com.alelievr.mixture/Editor/com.alelievr.Mixture.Editor.asmdef
@@ -1,14 +1,14 @@
 {
-    "name": "Unity.ShaderGraph.GraphicsTests",
+    "name": "com.alelievr.Mixture.Editor",
     "rootNamespace": "",
     "references": [
-        "Unity.ShaderGraph.Editor",
-        "Mixture.Runtime",
-        "com.alelievr.NodeGraphProcessor.Runtime",
-        "com.alelievr.NodeGraphProcessor.Editor",
-        "Unity.RenderPipelines.HighDefinition.Runtime",
-        "Unity.RenderPipelines.Core.Editor",
-        "Unity.RenderPipelines.Core.Runtime"
+        "GUID:fe40ba3f519cd4795b386f0ccc63a5a7",
+        "GUID:ca937d03ee5dd4d699091438dc0f3ae6",
+        "GUID:a432eb0a70c5c4a37ab50d59671586f8",
+        "GUID:457756d89b35d2941b3e7b37b4ece6f1",
+        "GUID:3eae0364be2026648bf74846acb8a731",
+        "GUID:df380645f10b7bc4b97d4f5eb6303d95",
+        "GUID:be0903cd8e1546f498710afdc59db5eb"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/com.alelievr.mixture/Runtime/PackageInfo.cs
+++ b/Packages/com.alelievr.mixture/Runtime/PackageInfo.cs
@@ -1,6 +1,4 @@
 using System.Runtime.CompilerServices;
 
-// Note: This is not the ShaderGraph asmdef but the editor asmdef of mixture
-// We need this hack because all the ShaderGraph API is internal ¯\_(ツ)_/¯
-[assembly: InternalsVisibleTo("Unity.ShaderGraph.GraphicsTests")]
+[assembly: InternalsVisibleTo("com.alelievr.Mixture.Editor")]
 [assembly: InternalsVisibleTo("com.alelievr.mixture-documentation")]

--- a/Packages/com.alelievr.mixture/Runtime/com.alelievr.Mixture.Runtime.asmdef
+++ b/Packages/com.alelievr.mixture/Runtime/com.alelievr.Mixture.Runtime.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Mixture.Runtime",
+    "name": "com.alelievr.Mixture.Runtime",
     "rootNamespace": "",
     "references": [
         "GUID:ca937d03ee5dd4d699091438dc0f3ae6",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "com.alelievr.mixture": "file:com.alelievr.mixture",
-    "com.alelievr.node-graph-processor": "1.3.0",
+    "com.alelievr.node-graph-processor": "https://github.com/alelievr/NodeGraphProcessor.git?path=/Assets/com.alelievr.NodeGraphProcessor",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.barracuda": "1.0.4",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -11,10 +11,11 @@
       }
     },
     "com.alelievr.node-graph-processor": {
-      "version": "file:C:/Users/Antoine Lelievre/Github/NodeGraphProcessor/Assets/com.alelievr.NodeGraphProcessor",
+      "version": "https://github.com/alelievr/NodeGraphProcessor.git?path=/Assets/com.alelievr.NodeGraphProcessor",
       "depth": 0,
-      "source": "local",
-      "dependencies": {}
+      "source": "git",
+      "dependencies": {},
+      "hash": "bc71d48ba9dfc7e7062779d6d12b9ef269e521b1"
     },
     "com.autodesk.fbx": {
       "version": "4.0.0-pre.1",


### PR DESCRIPTION
I see that Mixture editor assembly use the name `Unity.ShaderGraph.GraphicsTests` to get around the issue of using internal type from `Unity.ShaderGraph.Editor` assembly.

This PR presents another way around this issue. I made the entire `Assets/Editor/CustomTextureShaderGraph` directory belongs to the `Unity.ShaderGraph.Editor` assembly using Assembly Reference file. Some code from `Assets/Editor/Utils/MixtureCallbacks` has to be transfered to this folder as well. Everything outside `CustomTextureShaderGraph` folder doesn't reference internal ShaderGraph types and thus remains untouched.

Some other small modification includes using GUIDs for assembly references, renaming assembly to a more consistent name.