### PR TITLE
[Fix] Revert runtime assembly name

### DIFF
--- a/Assets/Examples/2D Simple.asset
+++ b/Assets/Examples/2D Simple.asset
@@ -83,7 +83,7 @@ MonoBehaviour:
       height: 396
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Assets/Examples/CA1D/CA1D-Anisotropic-K3.asset
+++ b/Assets/Examples/CA1D/CA1D-Anisotropic-K3.asset
@@ -140,7 +140,7 @@ MonoBehaviour:
       height: 461
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Assets/Examples/CA1D/CA1D-Elementary.asset
+++ b/Assets/Examples/CA1D/CA1D-Elementary.asset
@@ -187,7 +187,7 @@ MonoBehaviour:
       height: 396
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Assets/Examples/CA1D/CA1D-Totalistic-K3.asset
+++ b/Assets/Examples/CA1D/CA1D-Totalistic-K3.asset
@@ -188,7 +188,7 @@ MonoBehaviour:
       height: 396
     opened: 1
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Assets/Examples/CA1D/CA1D-Totalistic-K4.asset
+++ b/Assets/Examples/CA1D/CA1D-Totalistic-K4.asset
@@ -229,7 +229,7 @@ MonoBehaviour:
       height: 396
     opened: 1
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Assets/Examples/Fluids.asset
+++ b/Assets/Examples/Fluids.asset
@@ -279,7 +279,7 @@ MonoBehaviour:
       height: 461
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Assets/Examples/ParameterTests.asset
+++ b/Assets/Examples/ParameterTests.asset
@@ -63,7 +63,7 @@ MonoBehaviour:
       height: 388
     opened: 1
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters:
   - id: 5

--- a/Assets/Examples/Resources/Test.asset
+++ b/Assets/Examples/Resources/Test.asset
@@ -126,7 +126,7 @@ MonoBehaviour:
       height: 200
     opened: 1
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters:
   - guid: 53ff927e-50da-487b-930a-715ca18fd1fc

--- a/Assets/Examples/SceneTest/TestTerrainTopology.asset
+++ b/Assets/Examples/SceneTest/TestTerrainTopology.asset
@@ -56,7 +56,7 @@ MonoBehaviour:
       height: 396
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Assets/Examples/StandaloneMixture/BlendGraph.asset
+++ b/Assets/Examples/StandaloneMixture/BlendGraph.asset
@@ -147,7 +147,7 @@ MonoBehaviour:
       height: 287
     opened: 1
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters:
   - id: 5

--- a/Assets/Examples/readme.asset
+++ b/Assets/Examples/readme.asset
@@ -867,7 +867,7 @@ MonoBehaviour:
       height: 200
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Packages/com.alelievr.mixture/Editor/Resources/Templates/RealtimeMixtureGraphTemplate.asset
+++ b/Packages/com.alelievr.mixture/Editor/Resources/Templates/RealtimeMixtureGraphTemplate.asset
@@ -182,7 +182,7 @@ MonoBehaviour:
       height: 461
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Packages/com.alelievr.mixture/Editor/Resources/Templates/StaticMixtureGraphTemplate.asset
+++ b/Packages/com.alelievr.mixture/Editor/Resources/Templates/StaticMixtureGraphTemplate.asset
@@ -440,7 +440,7 @@ MonoBehaviour:
       height: 396
     opened: 0
     editorType:
-      serializedType: Mixture.MixtureParameterView, Unity.ShaderGraph.GraphicsTests,
+      serializedType: Mixture.MixtureParameterView, com.alelievr.Mixture.Editor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
   serializedParameterList: []

--- a/Packages/com.alelievr.mixture/Runtime/com.alelievr.Mixture.Runtime.asmdef
+++ b/Packages/com.alelievr.mixture/Runtime/com.alelievr.Mixture.Runtime.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "com.alelievr.Mixture.Runtime",
+    "name": "Mixture.Runtime",
     "rootNamespace": "",
     "references": [
         "GUID:ca937d03ee5dd4d699091438dc0f3ae6",

--- a/docs/docfx/api/Mixture.BuildPlayerCallback.yml
+++ b/docs/docfx/api/Mixture.BuildPlayerCallback.yml
@@ -23,7 +23,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/BuildPlayerCallback.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static class BuildPlayerCallback
@@ -57,7 +57,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/BuildPlayerCallback.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -99,7 +99,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/BuildPlayerCallback.cs
     startLine: 22
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static void BuildMixtureAssetBundle(BuildTarget buildTarget)

--- a/docs/docfx/api/Mixture.ColorNodeView.yml
+++ b/docs/docfx/api/Mixture.ColorNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ColorNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ColorNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.ComputeShaderNodeView.yml
+++ b/docs/docfx/api/Mixture.ComputeShaderNodeView.yml
@@ -26,7 +26,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ComputeShaderNodeView.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -363,7 +363,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ComputeShaderNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected List<VisualElement> openButtonsUI
@@ -394,7 +394,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ComputeShaderNodeView.cs
     startLine: 24
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -435,7 +435,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ComputeShaderNodeView.cs
     startLine: 29
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected event Action computeShaderChanged
@@ -466,7 +466,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ComputeShaderNodeView.cs
     startLine: 31
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -502,7 +502,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ComputeShaderNodeView.cs
     startLine: 68
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected void AddOpenButton(VisualElement openButtonUI)

--- a/docs/docfx/api/Mixture.CurveNodeView.yml
+++ b/docs/docfx/api/Mixture.CurveNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/CurveNodeView.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/CurveNodeView.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.CustomTextureNodeView.yml
+++ b/docs/docfx/api/Mixture.CustomTextureNodeView.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/CustomTextureNodeView.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/CustomTextureNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnCreated()
@@ -390,7 +390,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/CustomTextureNodeView.cs
     startLine: 27
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -426,7 +426,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/CustomTextureNodeView.cs
     startLine: 104
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnRemoved()

--- a/docs/docfx/api/Mixture.ExternalOutputNodeView.yml
+++ b/docs/docfx/api/Mixture.ExternalOutputNodeView.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -362,7 +362,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
     startLine: 15
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -398,7 +398,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
     startLine: 28
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void BuildOutputNodeSettings()
@@ -431,7 +431,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
     startLine: 156
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnRemoved()

--- a/docs/docfx/api/Mixture.FixedShaderNodeView.yml
+++ b/docs/docfx/api/Mixture.FixedShaderNodeView.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/FixedShaderNodeView.cs
     startLine: 8
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -358,7 +358,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/FixedShaderNodeView.cs
     startLine: 18
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -394,7 +394,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/FixedShaderNodeView.cs
     startLine: 57
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected void Finalize()
@@ -424,7 +424,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/FixedShaderNodeView.cs
     startLine: 110
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnRemoved()

--- a/docs/docfx/api/Mixture.FloatNodeView.yml
+++ b/docs/docfx/api/Mixture.FloatNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/FloatNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/FloatNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.ForStartView.yml
+++ b/docs/docfx/api/Mixture.ForStartView.yml
@@ -23,7 +23,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ForStartView.cs
     startLine: 8
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ForStartView.cs
     startLine: 13
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnCreated()
@@ -390,7 +390,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ForStartView.cs
     startLine: 24
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.GradientNodeView.yml
+++ b/docs/docfx/api/Mixture.GradientNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/GradientNodeView.cs
     startLine: 8
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/GradientNodeView.cs
     startLine: 13
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.InlineTextureDrawer.yml
+++ b/docs/docfx/api/Mixture.InlineTextureDrawer.yml
@@ -25,7 +25,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/InlineTextureDrawer.cs
     startLine: 5
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class InlineTextureDrawer : MixturePropertyDrawer'
@@ -70,7 +70,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/InlineTextureDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public InlineTextureDrawer()
@@ -100,7 +100,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/InlineTextureDrawer.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public InlineTextureDrawer(string v)
@@ -133,7 +133,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/InlineTextureDrawer.cs
     startLine: 15
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)
@@ -179,7 +179,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/InlineTextureDrawer.cs
     startLine: 29
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override float GetPropertyHeight(MaterialProperty prop, string label, MaterialEditor editor)

--- a/docs/docfx/api/Mixture.MaterialBinderView.yml
+++ b/docs/docfx/api/Mixture.MaterialBinderView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MaterialBinderView.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MaterialBinderView.cs
     startLine: 13
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.MixtureAssetCallbacks.yml
+++ b/docs/docfx/api/Mixture.MixtureAssetCallbacks.yml
@@ -40,7 +40,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public class MixtureAssetCallbacks
@@ -73,7 +73,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 16
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string Extension
@@ -108,7 +108,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string customTextureShaderTemplate
@@ -143,7 +143,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 19
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderNodeCSharpTemplate
@@ -178,7 +178,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 20
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderNodeCGTemplate
@@ -213,7 +213,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 21
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderNodeDefaultName
@@ -248,7 +248,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 22
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderName
@@ -283,7 +283,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 23
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string csharpComputeShaderNodeTemplate
@@ -318,7 +318,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 24
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string computeShaderTemplate
@@ -353,7 +353,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 25
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string computeShaderDefaultName
@@ -388,7 +388,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 26
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string computeShaderNodeDefaultName
@@ -423,7 +423,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 28
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string customMipMapShader
@@ -458,7 +458,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 30
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: "[MenuItem(\"Assets/Create/\U0001F3A8 Static Mixture Graph\", false, 83)]\npublic static void CreateStaticMixtureGraph()"
@@ -500,7 +500,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 38
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: "[MenuItem(\"Assets/Create/\U0001F321️ Realtime Mixture Graph\", false, 83)]\npublic static void CreateRealtimeMixtureGraph()"
@@ -542,7 +542,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 65
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -590,7 +590,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 72
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -638,7 +638,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 79
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -686,7 +686,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 91
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -734,7 +734,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 98
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -782,7 +782,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureCallbacks.cs
     startLine: 105
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-

--- a/docs/docfx/api/Mixture.MixtureBlendDrawer.Blend.yml
+++ b/docs/docfx/api/Mixture.MixtureBlendDrawer.Blend.yml
@@ -45,7 +45,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public enum Blend
@@ -76,7 +76,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Normal = 0
@@ -108,7 +108,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Min = 1
@@ -140,7 +140,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Max = 2
@@ -172,7 +172,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Burn = 3
@@ -204,7 +204,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Darken = 4
@@ -236,7 +236,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Difference = 5
@@ -268,7 +268,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Dodge = 6
@@ -300,7 +300,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Divide = 7
@@ -332,7 +332,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Exclusion = 8
@@ -364,7 +364,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: HardLight = 9
@@ -396,7 +396,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: HardMix = 10
@@ -428,7 +428,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Lighten = 11
@@ -460,7 +460,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: LinearBurn = 12
@@ -492,7 +492,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: LinearDodge = 13
@@ -524,7 +524,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: LinearLight = 14
@@ -556,7 +556,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: LinearLightAddSub = 15
@@ -588,7 +588,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Multiply = 16
@@ -620,7 +620,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Negation = 17
@@ -652,7 +652,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Overlay = 18
@@ -684,7 +684,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: PinLight = 19
@@ -716,7 +716,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Screen = 20
@@ -748,7 +748,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: SoftLight = 21
@@ -780,7 +780,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: Subtract = 22
@@ -812,7 +812,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: VividLight = 23

--- a/docs/docfx/api/Mixture.MixtureBlendDrawer.yml
+++ b/docs/docfx/api/Mixture.MixtureBlendDrawer.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 5
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureBlendDrawer : MixturePropertyDrawer'
@@ -68,7 +68,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureBlendDrawer.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.MixtureChannelDrawer.yml
+++ b/docs/docfx/api/Mixture.MixtureChannelDrawer.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureChannelDrawer.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureChannelDrawer : MixturePropertyDrawer'
@@ -68,7 +68,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureChannelDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.MixtureDebugWindow.yml
+++ b/docs/docfx/api/Mixture.MixtureDebugWindow.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureDebugWindow.cs
     startLine: 8
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureDebugWindow : EditorWindow'
@@ -165,7 +165,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureDebugWindow.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -209,7 +209,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureDebugWindow.cs
     startLine: 20
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void OnEnable()
@@ -239,7 +239,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureDebugWindow.cs
     startLine: 25
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void OnGUI()

--- a/docs/docfx/api/Mixture.MixtureEditorUtils.yml
+++ b/docs/docfx/api/Mixture.MixtureEditorUtils.yml
@@ -46,7 +46,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static class MixtureEditorUtils
@@ -80,7 +80,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string mixtureEditorResourcesPath
@@ -115,7 +115,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderGraphTexture2DTemplate
@@ -150,7 +150,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderGraphTexture3DTemplate
@@ -185,7 +185,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderGraphTextureCubeTemplate
@@ -220,7 +220,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 13
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderTextTexture2DTemplate
@@ -255,7 +255,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderTextTexture3DTemplate
@@ -290,7 +290,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 15
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string shaderTextTextureCubeTemplate
@@ -325,7 +325,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 16
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly string computeShaderTemplate
@@ -360,7 +360,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 65
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Shader CreateNewShaderGraph(MixtureGraph graph, string name, OutputDimension dimension)
@@ -401,7 +401,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 83
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Shader CreateNewShaderText(MixtureGraph graph, string name, OutputDimension dimension)
@@ -442,7 +442,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 100
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static ComputeShader CreateComputeShader(MixtureGraph graph, string name)
@@ -481,7 +481,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 106
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static void ToggleMixtureGraphMode(MixtureGraph mixture)
@@ -516,7 +516,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 117
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static MixtureGraph GetGraphAtPath(string path)
@@ -553,7 +553,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 136
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D bugIcon { get; }
@@ -590,7 +590,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 142
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D pinIcon { get; }
@@ -627,7 +627,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 148
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D unpinIcon { get; }
@@ -664,7 +664,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 154
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D compareIcon { get; }
@@ -701,7 +701,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 160
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D fitIcon { get; }
@@ -738,7 +738,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 166
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D githubIcon { get; }
@@ -775,7 +775,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 172
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D featureRequestIcon { get; }
@@ -812,7 +812,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 178
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D documentationIcon { get; }
@@ -849,7 +849,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 184
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D lockOpen { get; }
@@ -886,7 +886,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 190
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D lockClose { get; }
@@ -923,7 +923,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 196
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Texture2D settingsIcon { get; }
@@ -960,7 +960,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Utils/MixtureEditorUtils.cs
     startLine: 201
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static Vector4 GetChannelsMask(PreviewChannels channels)

--- a/docs/docfx/api/Mixture.MixtureGraphView.yml
+++ b/docs/docfx/api/Mixture.MixtureGraphView.yml
@@ -30,7 +30,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureGraphView : BaseGraphView, IEventHandler, ITransform, ITransitionAnimations, IExperimentalFeatures, IVisualElementScheduler, IResolvedStyle, ISelection, IDisposable'
@@ -382,7 +382,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public MixtureGraphProcessor processor { get; }
@@ -417,7 +417,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 15
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public MixtureGraph graph { get; }
@@ -452,7 +452,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public MixtureNodeInspectorObject mixtureNodeInspector { get; }
@@ -487,7 +487,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 19
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public MixtureGraphView(EditorWindow window)
@@ -520,7 +520,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 28
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override List<Port> GetCompatiblePorts(Port startPort, NodeAdapter nodeAdapter)
@@ -560,7 +560,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 74
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override NodeInspectorObject CreateNodeInspectorObject()
@@ -595,7 +595,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 83
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
@@ -631,7 +631,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 164
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void ProcessGraph()
@@ -661,7 +661,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphView.cs
     startLine: 231
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void CreateNodeOfType(Type type, Vector2 position)

--- a/docs/docfx/api/Mixture.MixtureGraphWindow.yml
+++ b/docs/docfx/api/Mixture.MixtureGraphWindow.yml
@@ -26,7 +26,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphWindow.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureGraphWindow : BaseGraphWindow'
@@ -179,7 +179,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphWindow.cs
     startLine: 13
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static MixtureGraphWindow Open(MixtureGraph graph)
@@ -216,7 +216,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphWindow.cs
     startLine: 37
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected void OnEnable()
@@ -246,7 +246,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphWindow.cs
     startLine: 43
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void InitializeWindow(BaseGraph graph)
@@ -282,7 +282,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphWindow.cs
     startLine: 57
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void OnDestroy()
@@ -315,7 +315,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureGraphWindow.cs
     startLine: 63
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public MixtureGraph GetCurrentGraph()

--- a/docs/docfx/api/Mixture.MixtureNodeInspectorObject.yml
+++ b/docs/docfx/api/Mixture.MixtureNodeInspectorObject.yml
@@ -25,7 +25,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 326
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureNodeInspectorObject : NodeInspectorObject'
@@ -106,7 +106,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 328
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public event Action pinnedNodeUpdate
@@ -137,7 +137,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 330
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public List<BaseNodeView> pinnedNodes
@@ -168,7 +168,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 332
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void AddPinnedView(BaseNodeView view)
@@ -201,7 +201,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 342
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void RemovePinnedView(BaseNodeView view)

--- a/docs/docfx/api/Mixture.MixtureNodeInspectorObjectEditor.yml
+++ b/docs/docfx/api/Mixture.MixtureNodeInspectorObjectEditor.yml
@@ -29,7 +29,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -156,7 +156,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 73
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void OnHeaderGUI()
@@ -189,7 +189,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 79
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void OnEnable()
@@ -222,7 +222,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 92
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void OnDisable()
@@ -255,7 +255,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 97
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void UpdateNodeInspectorList()
@@ -288,7 +288,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 165
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override bool HasPreviewGUI()
@@ -323,7 +323,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 170
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnPreviewSettings()
@@ -356,7 +356,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 223
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnInteractivePreviewGUI(Rect previewRect, GUIStyle background)
@@ -394,7 +394,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/MixtureNodeInspectorObject.cs
     startLine: 261
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void HandleZoomAndPan(Rect previewRect)

--- a/docs/docfx/api/Mixture.MixtureNodeView.yml
+++ b/docs/docfx/api/Mixture.MixtureNodeView.yml
@@ -34,7 +34,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -376,7 +376,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected VisualElement previewContainer
@@ -407,7 +407,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 16
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected MixtureGraphView owner { get; }
@@ -442,7 +442,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected MixtureNode nodeTarget { get; }
@@ -477,7 +477,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 22
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected virtual string header { get; }
@@ -514,7 +514,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 23
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override bool hasSettings { get; }
@@ -552,7 +552,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 25
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected MixtureRTSettingsView settingsView
@@ -583,7 +583,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 32
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override VisualElement CreateSettingsView()
@@ -618,7 +618,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 60
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -654,7 +654,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 109
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected void Finalize()
@@ -684,7 +684,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 183
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected bool MaterialPropertiesGUI(Material material, bool fromInspector, bool autoLabelWidth = true)
@@ -723,7 +723,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 278
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected int GetMaterialHash(Material material)
@@ -758,7 +758,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 343
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected void CreateTexturePreview(VisualElement previewContainer, MixtureNode node)
@@ -793,7 +793,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureNodeView.cs
     startLine: 499
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected virtual void DrawImGUIPreview(MixtureNode node, Rect previewRect, float currentSlice)

--- a/docs/docfx/api/Mixture.MixtureParameterView.yml
+++ b/docs/docfx/api/Mixture.MixtureParameterView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureParameterView.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureParameterView : ExposedParameterView, IEventHandler, ITransform, ITransitionAnimations, IExperimentalFeatures, IVisualElementScheduler, IResolvedStyle, ISelectable'
@@ -282,7 +282,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureParameterView.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override IEnumerable<Type> GetExposedParameterTypes()

--- a/docs/docfx/api/Mixture.MixturePropertyDrawer.yml
+++ b/docs/docfx/api/Mixture.MixturePropertyDrawer.yml
@@ -28,7 +28,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixturePropertyDrawer : MaterialPropertyDrawer'
@@ -77,7 +77,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 19
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static void RegisterEditor(MaterialEditor editor, MixtureNodeView nodeView, MixtureGraph graph)
@@ -116,7 +116,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 24
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static void UnregisterGraph(MixtureGraph graph)
@@ -151,7 +151,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 33
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected MixtureGraph GetGraph(MaterialEditor editor)
@@ -186,7 +186,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 34
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected MixtureNodeView GetNodeView(MaterialEditor editor)
@@ -221,7 +221,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 36
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override sealed void OnGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor)
@@ -265,7 +265,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 51
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override float GetPropertyHeight(MaterialProperty prop, string label, MaterialEditor editor)
@@ -307,7 +307,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixturePropertyDrawer.cs
     startLine: 59
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected virtual void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.MixtureRTSettingsView.yml
+++ b/docs/docfx/api/Mixture.MixtureRTSettingsView.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureRTSettingsView.cs
     startLine: 13
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureRTSettingsView : VisualElement, IEventHandler, ITransform, ITransitionAnimations, IExperimentalFeatures, IVisualElementScheduler, IResolvedStyle'
@@ -238,7 +238,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureRTSettingsView.cs
     startLine: 15
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public const string headerStyleClass = "PropertyEditorHeader"
@@ -271,7 +271,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureRTSettingsView.cs
     startLine: 56
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public MixtureRTSettingsView(MixtureNode node, MixtureGraphView owner)
@@ -306,7 +306,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/MixtureRTSettingsView.cs
     startLine: 397
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void RegisterChangedCallback(Action callback)

--- a/docs/docfx/api/Mixture.MixtureSwizzleDrawer.yml
+++ b/docs/docfx/api/Mixture.MixtureSwizzleDrawer.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureSwizzleDrawer.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureSwizzleDrawer : MixturePropertyDrawer'
@@ -68,7 +68,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureSwizzleDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.MixtureToolbar.ImproveMixturePopupWindow.yml
+++ b/docs/docfx/api/Mixture.MixtureToolbar.ImproveMixturePopupWindow.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureToolbar.cs
     startLine: 31
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class ImproveMixturePopupWindow : PopupWindowContent'
@@ -64,7 +64,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureToolbar.cs
     startLine: 33
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly int width
@@ -99,7 +99,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureToolbar.cs
     startLine: 35
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override Vector2 GetWindowSize()
@@ -134,7 +134,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureToolbar.cs
     startLine: 40
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnGUI(Rect rect)

--- a/docs/docfx/api/Mixture.MixtureToolbar.yml
+++ b/docs/docfx/api/Mixture.MixtureToolbar.yml
@@ -23,7 +23,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureToolbar.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureToolbar : ToolbarView, IEventHandler, ITransform, ITransitionAnimations, IExperimentalFeatures, IVisualElementScheduler, IResolvedStyle'
@@ -250,7 +250,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureToolbar.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public MixtureToolbar(BaseGraphView graphView)
@@ -283,7 +283,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureToolbar.cs
     startLine: 51
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void AddButtons()

--- a/docs/docfx/api/Mixture.MixtureVector2Drawer.yml
+++ b/docs/docfx/api/Mixture.MixtureVector2Drawer.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureVector2Drawer.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureVector2Drawer : MixturePropertyDrawer'
@@ -68,7 +68,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureVector2Drawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.MixtureVector3Drawer.yml
+++ b/docs/docfx/api/Mixture.MixtureVector3Drawer.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureVector3Drawer.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class MixtureVector3Drawer : MixturePropertyDrawer'
@@ -68,7 +68,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureVector3Drawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.NodeInspectorSettingsPopupWindow.yml
+++ b/docs/docfx/api/Mixture.NodeInspectorSettingsPopupWindow.yml
@@ -26,7 +26,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/NodeInspectorSettingsPopupWindow.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class NodeInspectorSettingsPopupWindow : PopupWindowContent'
@@ -66,7 +66,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/NodeInspectorSettingsPopupWindow.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly int width
@@ -101,7 +101,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/NodeInspectorSettingsPopupWindow.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public static readonly int height
@@ -136,7 +136,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/NodeInspectorSettingsPopupWindow.cs
     startLine: 14
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override Vector2 GetWindowSize()
@@ -171,7 +171,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/NodeInspectorSettingsPopupWindow.cs
     startLine: 19
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public NodeInspectorSettingsPopupWindow(MixtureNodeInspectorObjectEditor inspector)
@@ -204,7 +204,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Graph/MixtureInspector/NodeInspectorSettingsPopupWindow.cs
     startLine: 24
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnGUI(Rect rect)

--- a/docs/docfx/api/Mixture.NodeTexturePreview.yml
+++ b/docs/docfx/api/Mixture.NodeTexturePreview.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/NodeTexturePreview.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class NodeTexturePreview : VisualElement, IEventHandler, ITransform, ITransitionAnimations, IExperimentalFeatures, IVisualElementScheduler, IResolvedStyle'
@@ -236,7 +236,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/NodeTexturePreview.cs
     startLine: 36
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public NodeTexturePreview(MixtureNodeView view)

--- a/docs/docfx/api/Mixture.OutputNodeView.yml
+++ b/docs/docfx/api/Mixture.OutputNodeView.yml
@@ -29,7 +29,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -363,7 +363,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 15
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected OutputNode outputNode
@@ -394,7 +394,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 16
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected MixtureGraph graph
@@ -425,7 +425,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 18
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected Dictionary<string, OutputTextureView> inputPortElements
@@ -456,7 +456,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 20
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -492,7 +492,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 99
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override bool RefreshPorts()
@@ -527,7 +527,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 106
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override VisualElement CreateSettingsView()
@@ -562,7 +562,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 143
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected virtual void BuildOutputNodeSettings()
@@ -594,7 +594,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputNodeView.cs
     startLine: 172
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)

--- a/docs/docfx/api/Mixture.OutputTextureView.yml
+++ b/docs/docfx/api/Mixture.OutputTextureView.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputTextureView.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class OutputTextureView : VisualElement, IEventHandler, ITransform, ITransitionAnimations, IExperimentalFeatures, IVisualElementScheduler, IResolvedStyle'
@@ -238,7 +238,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputTextureView.cs
     startLine: 45
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public OutputTextureView(MixtureGraphView graphView, OutputNodeView nodeView, OutputTextureSettings targetSettings)
@@ -275,7 +275,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputTextureView.cs
     startLine: 187
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void RefreshSettings()
@@ -305,7 +305,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/OutputTextureView.cs
     startLine: 234
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public void MovePort(PortView portView)

--- a/docs/docfx/api/Mixture.PrefabCaptureNodeView.yml
+++ b/docs/docfx/api/Mixture.PrefabCaptureNodeView.yml
@@ -24,7 +24,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/PrefabCaptureNodeView.cs
     startLine: 10
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -358,7 +358,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/PrefabCaptureNodeView.cs
     startLine: 19
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -394,7 +394,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/PrefabCaptureNodeView.cs
     startLine: 50
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected void Finalize()
@@ -424,7 +424,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/PrefabCaptureNodeView.cs
     startLine: 112
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnRemoved()

--- a/docs/docfx/api/Mixture.RandomColorNodeView.yml
+++ b/docs/docfx/api/Mixture.RandomColorNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/RandomColorNodeView.cs
     startLine: 5
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/RandomColorNodeView.cs
     startLine: 8
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.RangeDrawer.yml
+++ b/docs/docfx/api/Mixture.RangeDrawer.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/RangeDrawer.cs
     startLine: 5
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class RangeDrawer : MixturePropertyDrawer'
@@ -68,7 +68,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/RangeDrawer.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.SampleGradientNodeView.yml
+++ b/docs/docfx/api/Mixture.SampleGradientNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/SampleGradientNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/SampleGradientNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.SelfNodeView.yml
+++ b/docs/docfx/api/Mixture.SelfNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/SelfNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/SelfNodeView.cs
     startLine: 18
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.ShaderNodeView.yml
+++ b/docs/docfx/api/Mixture.ShaderNodeView.yml
@@ -25,7 +25,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ShaderNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -358,7 +358,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ShaderNodeView.cs
     startLine: 24
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override string header { get; }
@@ -396,7 +396,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ShaderNodeView.cs
     startLine: 26
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)
@@ -432,7 +432,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ShaderNodeView.cs
     startLine: 71
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected void Finalize()
@@ -462,7 +462,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ShaderNodeView.cs
     startLine: 200
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void OnRemoved()

--- a/docs/docfx/api/Mixture.ShowInInspectorDecorator.yml
+++ b/docs/docfx/api/Mixture.ShowInInspectorDecorator.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureShowInInspectorDrawer.cs
     startLine: 7
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class ShowInInspectorDecorator : MixturePropertyDrawer'
@@ -68,7 +68,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/MixtureShowInInspectorDrawer.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override float GetPropertyHeight(MaterialProperty prop, string label, MaterialEditor editor)

--- a/docs/docfx/api/Mixture.SplatterNodeView.yml
+++ b/docs/docfx/api/Mixture.SplatterNodeView.yml
@@ -21,7 +21,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/SplatterNodeView.cs
     startLine: 9
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-

--- a/docs/docfx/api/Mixture.TextureNodeView.yml
+++ b/docs/docfx/api/Mixture.TextureNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/TextureNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/TextureNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.ToggleNodeView.yml
+++ b/docs/docfx/api/Mixture.ToggleNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ToggleNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/ToggleNodeView.cs
     startLine: 17
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/api/Mixture.TooltipDrawerDecorator.yml
+++ b/docs/docfx/api/Mixture.TooltipDrawerDecorator.yml
@@ -23,7 +23,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/TooltipDrawer.cs
     startLine: 6
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: 'public class TooltipDrawerDecorator : MixturePropertyDrawer'
@@ -69,7 +69,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/TooltipDrawer.cs
     startLine: 8
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public string tooltip
@@ -100,7 +100,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/MaterialPropertyDrawers/TooltipDrawer.cs
     startLine: 11
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: protected override void DrawerGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor, MixtureGraph graph, MixtureNodeView nodeView)

--- a/docs/docfx/api/Mixture.VectorNodeView.yml
+++ b/docs/docfx/api/Mixture.VectorNodeView.yml
@@ -22,7 +22,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/VectorNodeView.cs
     startLine: 12
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: >-
@@ -357,7 +357,7 @@ items:
     path: ../../Packages/com.alelievr.mixture/Editor/Views/VectorNodeView.cs
     startLine: 15
   assemblies:
-  - Unity.ShaderGraph.GraphicsTests
+  - com.alelievr.Mixture.Editor
   namespace: Mixture
   syntax:
     content: public override void Enable(bool fromInspector)

--- a/docs/docfx/docfx.json
+++ b/docs/docfx/docfx.json
@@ -5,7 +5,7 @@
         {
           "files": [
             "Mixture.Runtime**.csproj",
-            "Unity.ShaderGraph.GraphicsTests**.csproj"
+            "com.alelievr.Mixture.Editor**.csproj"
           ],
 		  "src": "../../"
         }


### PR DESCRIPTION
The runtime assembly name change in #56 messed up texture assets and docfx files as they store the previous assembly name. This PR reverts the name change.

Also changed all editor assembly references to the new assembly name.