### PR TITLE
Draft: External Output QoL improvements

### DIFF
--- a/Packages/com.alelievr.mixture/Editor/Resources/ExternalOutputNodeView.uss
+++ b/Packages/com.alelievr.mixture/Editor/Resources/ExternalOutputNodeView.uss
@@ -2,3 +2,8 @@
 {
     visibility: hidden;
 }
+
+#title
+{
+    background-color: #003355;
+}

--- a/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
+++ b/Packages/com.alelievr.mixture/Editor/Views/ExternalOutputNodeView.cs
@@ -33,7 +33,7 @@ namespace Mixture
             var externalOutputNode = nodeTarget as ExternalOutputNode;
             var nodeSettings = new IMGUIContainer(() =>
             {
-                if(externalOutputNode.asset == null)
+                if (externalOutputNode.asset == null)
                 {
                     EditorGUILayout.HelpBox("This output has not been saved yet, please click Save As to save the output texture.", MessageType.Info);
                 }
@@ -48,7 +48,7 @@ namespace Mixture
                 if (EditorGUI.EndChangeCheck())
                 {
                     externalOutputNode.externalOutputDimension = (ExternalOutputNode.ExternalOutputDimension)outputDimension;
-                    switch(outputDimension)
+                    switch (outputDimension)
                     {
                         case ExternalOutputNode.ExternalOutputDimension.Texture2D:
                             externalOutputNode.settings.dimension = OutputDimension.Texture2D;
@@ -78,7 +78,7 @@ namespace Mixture
                 {
                     EditorGUI.BeginChangeCheck();
                     var outputType = EditorGUILayout.EnumPopup("Type", externalOutputNode.external2DOoutputType);
-                    if(EditorGUI.EndChangeCheck())
+                    if (EditorGUI.EndChangeCheck())
                     {
                         externalOutputNode.external2DOoutputType = (ExternalOutputNode.External2DOutputType)outputType;
                         MarkDirtyRepaint();
@@ -105,12 +105,15 @@ namespace Mixture
                     }
                 }
 
-                EditorGUI.BeginChangeCheck();
-                var exportAlpha = EditorGUILayout.Toggle("Export Alpha", externalOutputNode.exportAlpha);
-                if (EditorGUI.EndChangeCheck())
+                if (externalOutputNode.externalOutputDimension == ExternalOutputNode.ExternalOutputDimension.Texture2D)
                 {
-                    externalOutputNode.exportAlpha = exportAlpha;
-                    MarkDirtyRepaint();
+                    EditorGUI.BeginChangeCheck();
+                    var exportAlpha = EditorGUILayout.Toggle("Export Alpha", externalOutputNode.exportAlpha);
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        externalOutputNode.exportAlpha = exportAlpha;
+                        MarkDirtyRepaint();
+                    }
                 }
 
                 externalOutputNode.previewSRGB =

--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -632,6 +632,21 @@ namespace Mixture
                 }
                 else if (dimension == TextureDimension.Tex2D)
                 {
+                    // Pre-process (fill alpha with 1s when export alpha is false)
+                    if(!external.exportAlpha)
+                    {
+                        var pixels = (outputTexture as Texture2D).GetPixels();
+                        for(int i = 0; i< pixels.Length; i++)
+                        {
+                            var c = pixels[i];
+                            c.a = 1f;
+                            pixels[i] = c;
+                        }
+                        (outputTexture as Texture2D).SetPixels(pixels);
+                        (outputTexture as Texture2D).Apply();
+                    }
+
+
                     byte[] contents = null;
 
                     if (external.externalFileType == ExternalOutputNode.ExternalFileType.EXR)

--- a/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
+++ b/Packages/com.alelievr.mixture/Runtime/Graph/MixtureGraph.cs
@@ -8,6 +8,7 @@ using UnityEngine.Experimental.Rendering;
 using System;
 using Object = UnityEngine.Object;
 using UnityEngine.Serialization;
+using System.IO;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -596,7 +597,8 @@ namespace Mixture
                             throw new NotImplementedException($"File type not handled : '{external.externalFileType}'");
                     }
 
-                    assetPath = EditorUtility.SaveFilePanelInProject("Save Texture", external.name, extension, "Save Texture");
+
+                    assetPath = EditorUtility.SaveFilePanelInProject("Save Texture", external.name, extension, "Save Texture", Path.GetDirectoryName(external.graph.mainAssetPath));
 
                     if (string.IsNullOrEmpty(assetPath))
                     {


### PR DESCRIPTION
- Made External Output node stand out (Slight Tint)
- Fixes default path : now same as mixture asset
- Fixes in Alpha : remove alpha when full white / Export Alpha for dimensions other than Texture2D